### PR TITLE
Axios upgraded to 0.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/arvind-agarwal/node_extra_ca_certs_mozilla_bundle#readme",
   "dependencies": {
-    "axios": "^0.27.2",
+    "axios": "^0.28.1",
     "cross-env": "^6.0.3",
     "csvtojson": "^2.0.10"
   }


### PR DESCRIPTION
Upgraded the Axios version to 0.28.1. This is done to resolve the Axios Dependabot alerts on Sprinto.